### PR TITLE
Fix function keys.

### DIFF
--- a/MediaKeyTap/MediaKeyTap.swift
+++ b/MediaKeyTap/MediaKeyTap.swift
@@ -128,11 +128,8 @@ public class MediaKeyTap {
 
 	public static func functionKeyCodeToMediaKey(_ keycode: Keycode) -> MediaKey? {
 		switch keycode {
-		case 113, 120, 144: return .brightnessUp
-		case 107, 122, 145: return .brightnessDown
-		case 111 : return .volumeUp
-		case 103 : return .volumeDown
-		case 109 : return .mute
+		case 113, 144: return .brightnessUp
+		case 107, 145: return .brightnessDown
 		default: return nil
 		}
 	}

--- a/MediaKeyTap/MediaKeyTap.swift
+++ b/MediaKeyTap/MediaKeyTap.swift
@@ -70,7 +70,7 @@ public class MediaKeyTap {
 
     // MARK: - Setup
 
-	public init(delegate: MediaKeyTapDelegate, on mode: KeyPressMode = .keyDown, forKeys keys: [MediaKey], observeBuiltIn: Bool = true) {
+	public init(delegate: MediaKeyTapDelegate, on mode: KeyPressMode = .keyDown, for keys: [MediaKey] = [], observeBuiltIn: Bool = true) {
         self.delegate = delegate
         self.interceptMediaKeys = false
         self.mediaApplicationWatcher = MediaApplicationWatcher()


### PR DESCRIPTION
While MonitorControl is running, I cannot press F1/F2/F10/F11/F12, since e.g. both <kbd>Fn + F1</kbd> and <kbd>F1</kbd> are detected as “brightness down”, even though <kbd>Fn + F1</kbd> should be the actual function key.

Would be great if you could include this into a new release of MonitorControl.