### PR TITLE
Fix F14, F15 should not trigger brightness

### DIFF
--- a/MediaKeyTap/MediaKeyTap.swift
+++ b/MediaKeyTap/MediaKeyTap.swift
@@ -128,8 +128,8 @@ public class MediaKeyTap {
 
   public static func functionKeyCodeToMediaKey(_ keycode: Keycode) -> MediaKey? {
     switch keycode {
-    case 113, 144: return .brightnessUp
-    case 107, 145: return .brightnessDown
+    case 144: return .brightnessUp
+    case 145: return .brightnessDown
     default: return nil
     }
   }

--- a/MediaKeyTap/MediaKeyTap.swift
+++ b/MediaKeyTap/MediaKeyTap.swift
@@ -42,6 +42,7 @@ public protocol MediaKeyTapDelegate {
 }
 
 public class MediaKeyTap {
+  public static var useAlternateBrightnessKeys: Bool = true
   let delegate: MediaKeyTapDelegate
   let mediaApplicationWatcher: MediaApplicationWatcher
   let internals: MediaKeyTapInternals
@@ -128,8 +129,10 @@ public class MediaKeyTap {
 
   public static func functionKeyCodeToMediaKey(_ keycode: Keycode) -> MediaKey? {
     switch keycode {
-    case 144: return .brightnessUp
-    case 145: return .brightnessDown
+    case 107: return (useAlternateBrightnessKeys ? .brightnessDown : nil) // F14
+    case 113: return (useAlternateBrightnessKeys ? .brightnessUp : nil) // F15
+    case 144: return .brightnessUp // Brightness up media key
+    case 145: return .brightnessDown // Brightness down media key
     default: return nil
     }
   }


### PR DESCRIPTION
fixes #6 

Implements changes that have impact on https://github.com/MonitorControl/MonitorControl/issues/100.

key codes related to this PR:
113: F15,
144: brightness up
107: F14
145: brightness down

I don't have a keyboard with f keys above 12 so I used AppleScript to test them.

AppleScript testing example:
```
tell application "System Events"
	key code 107
end tell
```