### PR TITLE
Add more failure factors to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ The MediaKeyTap initialiser allows the keypress behaviour to be specified:
 
 ## Requirements
 
-* In order to capture key events globally, your application cannot be sandboxed or you will not receive any events.
+In order to capture key events globally, you need to ensure:
+
+* Your application is not sandboxed
+* Your info.plist provides `NSAppleEventsUsageDescription`
+* Your application has accessibility privileges (will be asked automatically)
 
 ## Installation
 


### PR DESCRIPTION
I needed to search quite a while for https://stackoverflow.com/questions/52738506/cgeventtapcreate-returns-null-in-macos-mojave to figure out why in news builds, MediaKeyTap doesn't work anymore. This information might come in handy for other people, too.